### PR TITLE
Update PID.py

### DIFF
--- a/simple_pid/PID.py
+++ b/simple_pid/PID.py
@@ -111,7 +111,10 @@ class PID(object):
 
         now = self.time()
         if dt is None:
-            dt = utime.ticks_diff(now,self._last_time) if (utime.ticks_diff(now,self._last_time)) else 1e-16
+            if self.scale == 'time':
+                dt = (now - self._last_time) if (now - self._last_time) else 1e-16
+            else:    
+                dt = utime.ticks_diff(now,self._last_time) if (utime.ticks_diff(now,self._last_time)) else 1e-16
         elif dt <= 0:
             raise ValueError('dt has negative value {}, must be positive'.format(dt))
 


### PR DESCRIPTION
ticks_diff does not work on time() values on many platforms - see https://docs.micropython.org/en/v1.15/library/utime.html?highlight=time#utime.ticks_diff

In particular, it doesn't give the correct answers on the RP2350